### PR TITLE
Stopper le serveur 

### DIFF
--- a/untitled/src/main/java/sockets/ListenStop.java
+++ b/untitled/src/main/java/sockets/ListenStop.java
@@ -27,17 +27,11 @@ public class ListenStop implements Callable<Void> {
 
     @Override
     public Void call() throws Exception {
-
+        log("Start to listen the stop port");
         ServerSocket serverSocket = new ServerSocket(2135);
         Socket socket = serverSocket.accept();
+        log("Interrupt the main thread");
         threadMain.interrupt();
-
-
-
-
-
-
-
         return null;
     }
 

--- a/untitled/src/main/java/sockets/ListenStop.java
+++ b/untitled/src/main/java/sockets/ListenStop.java
@@ -13,9 +13,11 @@ import java.net.Socket;
 public class ListenStop implements Callable<Void> {
 
     private Thread threadMain;
+    private ServerSocket serverSocketMain;
 
-    public ListenStop(Thread threadMain){
+    public ListenStop(Thread threadMain, ServerSocket serverSocketMain){
         this.threadMain = threadMain;
+        this.serverSocketMain = serverSocketMain;
     }
     private void log(String msg) {
         DateFormat format = new SimpleDateFormat("hh:mm:ss.zzz");
@@ -32,6 +34,7 @@ public class ListenStop implements Callable<Void> {
         Socket socket = serverSocket.accept();
         log("Interrupt the main thread");
         threadMain.interrupt();
+        serverSocketMain.close();
         return null;
     }
 

--- a/untitled/src/main/java/sockets/Server.java
+++ b/untitled/src/main/java/sockets/Server.java
@@ -37,6 +37,7 @@ public class Server {
 
         log("Waiting for a new connection...");
         while(!Thread.interrupted()){
+            log("Thread.interrupted : " + Thread.interrupted());
             Socket socket = serverSocket.accept();
 
             log("Pile up the thread " + nbThread);
@@ -44,7 +45,7 @@ public class Server {
             this.nbThread++;
             resultList.add(result);
         }
-
+        log("I'm interrupted.");
         for (Future<Void> result : resultList) {
             try {
                 result.get();

--- a/untitled/src/main/java/sockets/Server.java
+++ b/untitled/src/main/java/sockets/Server.java
@@ -33,17 +33,22 @@ public class Server {
             resultList.add(result);
         }*/
 
-        pool.submit(new ListenStop(Thread.currentThread()));
+        pool.submit(new ListenStop(Thread.currentThread(), serverSocket));
 
         log("Waiting for a new connection...");
         while(!Thread.interrupted()){
             log("Thread.interrupted : " + Thread.interrupted());
-            Socket socket = serverSocket.accept();
 
-            log("Pile up the thread " + nbThread);
-            Future<Void> result = pool.submit(new Worker(socket, nbThread));
-            this.nbThread++;
-            resultList.add(result);
+            try {
+                Socket socket = serverSocket.accept();
+                log("Pile up the thread " + nbThread);
+                Future<Void> result = pool.submit(new Worker(socket, nbThread));
+                this.nbThread++;
+                resultList.add(result);
+            } catch (IOException e) {
+                log("IOException break the boucle");
+                break;
+            }
         }
         log("I'm interrupted.");
         for (Future<Void> result : resultList) {


### PR DESCRIPTION
Le code fonctionnait mais le problème est que serverSocket.accept est un appel bloquant. On doit donc attendre de charger une page pour que l’arrêt soit effectif. 

```java
while(!Thread.interrupted()){
        	Socket socket = serverSocket.accept(); 

        	log("Pile up the thread " + nbThread);
        	Future<Void> result = pool.submit(new Worker(socket, nbThread));
        	this.nbThread++;
        	resultList.add(result);
 }
```

Exemple de test pour le voir : 
se connecter à : http://localhost:2135/ puis se connecter à http://localhost:2134/

J'ai regardé s'il n'y avait pas une solution pour obtenir plus de réactivité. Voici la solution que j'ai trouvée : https://stackoverflow.com/questions/2983835/how-can-i-interrupt-a-serversocket-accept-method

Il s'agit de passer la socket du serveur et d'ajouter cette ligne au ServerStop : 
```java
serverSocketMain.close();
```
Une erreur IO est alors générée dans le thread main, j'en profite pour capturer l’erreur et quitter la boucle. 
