### PR TITLE
Ajout du client et de l'erreur 404

### DIFF
--- a/restful/pom.xml
+++ b/restful/pom.xml
@@ -21,7 +21,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/restful/src/main/java/enseirb/concurrence/restful/RestfulClient.java
+++ b/restful/src/main/java/enseirb/concurrence/restful/RestfulClient.java
@@ -1,0 +1,41 @@
+package enseirb.concurrence.restful;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.Scanner;
+
+public class RestfulClient {
+
+    public static void main(String[] args) {
+
+        // Creation of the Spring context
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(WebClientConfig.class);
+
+        // Retrieval of the TruckRepositoryClient bean from the context
+        TruckRepositoryClient truckRepositoryClient = context.getBean(TruckRepositoryClient.class);
+
+        try {
+            Scanner in = new Scanner(System.in);
+            System.out.println("Type the id of the truck");
+            long id = in.nextLong();
+
+            Truck truck = truckRepositoryClient.getById(id);
+
+            // Result
+            if (truck != null) {
+                System.out.println("Truck Details:");
+                System.out.println("License Plate: " + truck.getLicencePlate());
+                System.out.println("First release date: " + truck.getFirstReleaseDate());
+                System.out.println("Unloaded weight: " + truck.getUnloadedWeight());
+            } else {
+                System.out.println("Truck not found.");
+            }
+        } catch (WebClientResponseException.NotFound e) {
+            System.out.println("404 Error, the id isn't valid!");
+        }
+
+        // Closing the Spring context
+        context.close();
+    }
+}

--- a/restful/src/main/java/enseirb/concurrence/restful/Truck.java
+++ b/restful/src/main/java/enseirb/concurrence/restful/Truck.java
@@ -5,8 +5,12 @@ import java.time.Instant;
 
 public class Truck {
     private String licencePlate;
-    private Instant firstReleaseDate;
-    private int unloadedWeight;
+        private Instant firstReleaseDate;
+        private int unloadedWeight;
+
+    // Constructor without argument for JSON deserialization
+    public Truck() {
+    }
 
     public Truck(String licencePlate, Instant firstReleaseDate, int unloadedWeight){
         this.licencePlate = licencePlate;
@@ -17,10 +21,21 @@ public class Truck {
     public int getUnloadedWeight() {
         return unloadedWeight;
     }
+
     public Instant getFirstReleaseDate() {
         return firstReleaseDate;
     }
     public String getLicencePlate() {
         return licencePlate;
+    }
+    public void setFirstReleaseDate(Instant firstReleaseDate) {
+        this.firstReleaseDate = firstReleaseDate;
+    }
+    public void setLicencePlate(String licencePlate) {
+        this.licencePlate = licencePlate;
+    }
+
+    public void setUnloadedWeight(int unloadedWeight) {
+        this.unloadedWeight = unloadedWeight;
     }
 }

--- a/restful/src/main/java/enseirb/concurrence/restful/TruckController.java
+++ b/restful/src/main/java/enseirb/concurrence/restful/TruckController.java
@@ -1,6 +1,8 @@
 package enseirb.concurrence.restful;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,7 +17,12 @@ public class TruckController {
     @Autowired TruckRepository truckRepo;
 
     @GetMapping("/{id}")
-    public Truck getTruckById(@PathVariable long id){
-        return truckRepo.getTruckById(id);
+    public ResponseEntity<Truck> getById(@PathVariable long id){
+        try {
+            Truck truck = truckRepo.getTruckById(id);
+            return new ResponseEntity<>(truck, HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/restful/src/main/java/enseirb/concurrence/restful/TruckRepository.java
+++ b/restful/src/main/java/enseirb/concurrence/restful/TruckRepository.java
@@ -24,7 +24,7 @@ public class TruckRepository {
         truckList.remove(id, truck);
     }
 
-    public Truck getTruckById(Long id){
+    public Truck getTruckById(Long id) throws IllegalArgumentException {
         Truck truck = truckList.get(id);
         if(truck == null){
             throw new IllegalArgumentException("Truck does not exist");

--- a/restful/src/main/java/enseirb/concurrence/restful/TruckRepositoryClient.java
+++ b/restful/src/main/java/enseirb/concurrence/restful/TruckRepositoryClient.java
@@ -1,0 +1,19 @@
+package enseirb.concurrence.restful;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class TruckRepositoryClient {
+    @Autowired
+    WebClient truckClient;
+    public Truck getById(long id) {
+        return truckClient.get().uri("/truck/{id}", id)
+                .retrieve()
+                .bodyToMono(Truck.class)
+                .block();
+    }
+
+}

--- a/restful/src/main/java/enseirb/concurrence/restful/WebClientConfig.java
+++ b/restful/src/main/java/enseirb/concurrence/restful/WebClientConfig.java
@@ -1,0 +1,17 @@
+package enseirb.concurrence.restful;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@ComponentScan("enseirb.concurrence.restful")
+public class WebClientConfig {
+    public static final String TRUCK_URL = "http://localhost:8080";
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().baseUrl(TRUCK_URL).build();
+    }
+}


### PR DESCRIPTION
J'ai implémenté la technique où il y a deux processus. Pour tester il faut lancer le main de : 
- RestfulApplication pour run le serveur 
- RestfulClient pour run le client 

Le client propose alors d'entrer un identifiant dans la console. Pour 0, il affiche le camion et pour 2, il indique qu'il a obtenu une erreur 404. 

Le décorateur `@ComponentScan("enseirb.concurrence.restful")` dans la classe `WebClientConfig` permet d'indiquer les packages à scanner pour trouver le bean : https://www.baeldung.com/spring-nosuchbeandefinitionexception#cause-1

Dans `RestfulClient`, j'ai défini un contexte car sinon je n'arrivais pas à instancier `TruckRepositoryClient ` notamment à cause du décorateur `@Autowired`.